### PR TITLE
[receiver/sqlquery] Decrease time of running integration tests

### DIFF
--- a/receiver/sqlqueryreceiver/testdata/integration/mysql/init.sql
+++ b/receiver/sqlqueryreceiver/testdata/integration/mysql/init.sql
@@ -21,7 +21,7 @@ values ('Mission Impossible', 'Action', 7.1);
 create table simple_logs
 (
     id integer,
-    insert_time timestamp,
+    insert_time timestamp default now(),
     body text,
     attribute text,
     primary key (id)

--- a/receiver/sqlqueryreceiver/testdata/integration/oracle/Dockerfile.oracledb
+++ b/receiver/sqlqueryreceiver/testdata/integration/oracle/Dockerfile.oracledb
@@ -1,9 +1,0 @@
-FROM gvenzl/oracle-xe:21-slim-faststart
-
-ENV ORACLE_PASSWORD=mysecurepassword
-
-RUN mkdir -p /container-entrypoint-initdb.d
-
-COPY init.sql /container-entrypoint-initdb.d/startup.sql
-
-HEALTHCHECK CMD "$ORACLE_BASE/healthcheck.sh"

--- a/receiver/sqlqueryreceiver/testdata/integration/oracle/init.sql
+++ b/receiver/sqlqueryreceiver/testdata/integration/oracle/init.sql
@@ -1,10 +1,9 @@
 /* The alter session command is required to enable user creation in an Oracle docker container
    This command shouldn't be used outside of test environments. */
 alter session set "_ORACLE_SCRIPT"=true;
-CREATE USER OTEL IDENTIFIED BY "p@ssw%rd";
-GRANT CREATE SESSION TO OTEL;
-GRANT ALL PRIVILEGES TO OTEL;
-ALTER USER OTEL QUOTA UNLIMITED ON USERS;
+ALTER SESSION SET CONTAINER=FREEPDB1;
+CREATE USER OTEL IDENTIFIED BY otel QUOTA UNLIMITED ON USERS
+GRANT CONNECT, RESOURCE TO OTEL;
 -- Switch to the OTEL schema
 ALTER SESSION SET CURRENT_SCHEMA = OTEL;
       
@@ -30,7 +29,7 @@ values ('Mission Impossible', 'Action', 7.1);
 create table simple_logs
 (
     id number primary key,
-    insert_time timestamp with time zone,
+    insert_time timestamp with time zone default SYSTIMESTAMP,
     body varchar2(4000),
     attribute varchar2(100)
 );

--- a/receiver/sqlqueryreceiver/testdata/integration/postgresql/init.sql
+++ b/receiver/sqlqueryreceiver/testdata/integration/postgresql/init.sql
@@ -24,11 +24,11 @@ grant select on movie to otel;
 create table simple_logs
 (
     id integer primary key,
-    insert_time timestamp,
+    insert_time timestamp default now(),
     body text,
     attribute text
 );
-grant select, insert on simple_logs to otel;
+grant select, insert, delete on simple_logs to otel;
 
 insert into simple_logs (id, insert_time, body, attribute) values
 (1, '2022-06-03 21:59:26+00', '- - - [03/Jun/2022:21:59:26 +0000] "GET /api/health HTTP/1.1" 200 6197 4 "-" "-" 445af8e6c428303f -', 'TLSv1.2'),

--- a/receiver/sqlqueryreceiver/testdata/integration/sqlserver/init.sql
+++ b/receiver/sqlqueryreceiver/testdata/integration/sqlserver/init.sql
@@ -35,7 +35,7 @@ PRINT 'Data inserted into movie table.';
 CREATE TABLE simple_logs
 (
     id INT PRIMARY KEY,
-    insert_time DATETIME2,
+    insert_time DATETIME2 default GETDATE(),
     body NVARCHAR(MAX),
     attribute NVARCHAR(100)
 );


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Improvements to integration test for sqlqueryreciver:
1. Reduced test execution time by changing the behavior from starting and shutting down the database container for each test case to starting the container **once** and then running all tests for the given engine.

2. Updated the Oracle container from [gvenzl/oracle-xe:21-slim-faststart](https://hub.docker.com/r/gvenzl/oracle-xe) to [gvenzl/oracle-free:slim-faststart](https://hub.docker.com/r/gvenzl/oracle-free), primarily to support ARM architecture.


<!--Describe what testing was performed and which tests were added.-->
#### Testing
* Ran tests for Oracle and SQL Server locally to ensure they are not broken.

<!--Describe the documentation added.-->
#### Documentation
N/A

<!--Please delete paragraphs that you did not use before submitting.-->
